### PR TITLE
update gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,12 +3,14 @@
 /[Oo]bj/
 /[Bb]uild/
 /[Bb]uilds/
-/Assets/AssetStoreTools*
 /ProjectSettings
-/Assets/Dependencies
-/Assets/Dependencies.meta
+/Assets/*
 
+# Whitelisted from gitignore
+!Assets/[Hh]otmax*
 
+# ignore all generated meta files
+/Assets/*.meta
 
 # Visual Studio 2015 cache directory
 /.vs/
@@ -27,6 +29,7 @@ ExportedObj/
 *.svd
 *.pdb
 *.cfg
+
 
 # Unity3D generated meta files
 *.pidb.meta


### PR DESCRIPTION
I was having to modify too many dependencies because they were made to be directly under the Assets folder. Anything that contains "[Hh]otmax", is not ignored. Everything else is ignored by default.  